### PR TITLE
Create embedded ruby ruby for static_pages: home, help, and about

### DIFF
--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -3,7 +3,7 @@
 <html>
   <head>
     <title>
-      <%= yield(:title) %> Ruby on Rails Tutorial Sample App
+      <%= yield(:title) %> | Ruby on Rails Tutorial Sample App
     </title>
   </head>
   <body class="about-page">

--- a/app/views/static_pages/help.html.erb
+++ b/app/views/static_pages/help.html.erb
@@ -1,9 +1,9 @@
 <% provide(:title, "Help") %>
 <!DOCTYPE html>
-<html lang="en" xml:lang="en">
+<html>
   <head>
     <title>
-      <%= yield(:title) %> Ruby on Rails Tutorial Sample App
+      <%= yield(:title) %> | Ruby on Rails Tutorial Sample App
     </title>
   </head>
   <body>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,9 +1,14 @@
-<% provide(:title, "Page Title") %>
+<%
+=begin%>
+ <% provide(:title, "Page Title") %> 
+<%
+=end%>
 <!DOCTYPE html>
  <html lang="en">
   <head>
-    <title><%= yield(:title) %> Ruby on Rails Tutorial Sample App</title>
-    <meta content="text/html; charset=utf-8" />
+    <title>
+      Home | Ruby on Rails Tutorial Sample App
+      </title>
   </head>
   <body>
     <div>

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -1,14 +1,13 @@
 require 'test_helper'
 class StaticPagesControllerTest < ActionDispatch::IntegrationTest
- 
   def setup
-    @base_title = 'Ruby on Rails Tutorial Sample App'
+    @base_title = "Ruby on Rails Tutorial Sample App"
   end
 
   test 'should get home page for static_pages controller' do
     get static_pages_home_url
     assert_response :success
-    assert_select 'title', "Home | #{@base_title}"
+    assert_select "title", "Home | #{@base_title}"
   end
 
   test 'should get help page for static_pages controller' do


### PR DESCRIPTION
- StaticPagesController create setup method that sets and returns @base_title equal to a shared string across all pages.
- In static_pages: home, about, and help actions I applied `<% provide(:title, "Home") %> helper that is interpolated into the reused @base_title method defined in the controller and it then yields the correct text based on the route and a ```<% provide(:title, title) %><%= yield(:title) %>``` erb template. 
- Added assert_select "title", "<expected_title> | #{@base_title}" spec and run bin/rails test with 6 running and 0 failures. TDD red, green, REFACTOR!
- This took longer than expected because in the process of install ohmyzsh I royally messed up my config and had to reconfigure after spending my max limit on trying to fix. All is working now! Wont make that mistake again!! :)